### PR TITLE
fix: scale crop coordinates for Wayland fractional scaling (#16)

### DIFF
--- a/crates/region-portal/src/pipewire.rs
+++ b/crates/region-portal/src/pipewire.rs
@@ -209,6 +209,74 @@ fn extract_region(frame: &PipeWireFrame, region: &Rectangle) -> Arc<Vec<u8>> {
     Arc::new(dst)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_frame(width: u32, height: u32) -> PipeWireFrame {
+        let bpp = 4;
+        let size = (width * height * bpp as u32) as usize;
+        let mut data = vec![0u8; size];
+        // Fill with a pattern: each pixel's first byte = (x + y * width) % 256
+        for y in 0..height {
+            for x in 0..width {
+                let offset = ((y * width + x) as usize) * bpp;
+                data[offset] = ((x + y * width) % 256) as u8;
+                data[offset + 1] = 0;
+                data[offset + 2] = 0;
+                data[offset + 3] = 255;
+            }
+        }
+        PipeWireFrame {
+            width,
+            height,
+            data: Arc::new(data),
+            format: PixelFormat::BGRA8888,
+            timestamp: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn extract_region_full_frame() {
+        let frame = make_frame(100, 100);
+        let region = Rectangle::new(0, 0, 100, 100);
+        let result = extract_region(&frame, &region);
+        assert_eq!(result.len(), frame.data.len());
+    }
+
+    #[test]
+    fn extract_region_subset() {
+        let frame = make_frame(100, 100);
+        let region = Rectangle::new(10, 20, 30, 40);
+        let result = extract_region(&frame, &region);
+        let bpp = 4;
+        let expected_size = 30 * 40 * bpp;
+        assert_eq!(result.len(), expected_size);
+
+        // Verify first pixel of extracted region matches source
+        let src_offset = (20 * 100 + 10) * bpp;
+        assert_eq!(result[0], frame.data[src_offset]);
+    }
+
+    #[test]
+    fn extract_region_with_scaled_coordinates() {
+        // Simulate fractional scaling: frame is 5120x2160, region is in
+        // scaled coordinates that have been properly adjusted
+        let frame = make_frame(200, 100);
+
+        // Without scaling: region at (75, 50, 50, 25) in a 150x75 logical space
+        // After scaling by 200/150 = 1.333: (100, 66, 66, 33)
+        let scaled_region = Rectangle::new(100, 66, 66, 33);
+        let result = extract_region(&frame, &scaled_region);
+        let bpp = 4;
+        assert_eq!(result.len(), 66 * 33 * bpp);
+
+        // Verify first pixel comes from the right source position
+        let src_offset = (66 * 200 + 100) * bpp;
+        assert_eq!(result[0], frame.data[src_offset]);
+    }
+}
+
 /// Run the PipeWire main loop with portal fd (must run on its own thread).
 fn run_pipewire_loop_with_fd(
     node_id: u32,

--- a/crates/region-portal/src/stream.rs
+++ b/crates/region-portal/src/stream.rs
@@ -13,6 +13,9 @@ pub struct PortalBackend {
     pipewire_stream: Option<PipeWireStream>,
     region: Rectangle,
     screen_size: (u32, u32),
+    /// Portal-reported stream size, which may differ from actual PipeWire
+    /// frame dimensions under Wayland fractional scaling.
+    portal_reported_size: Option<(u32, u32)>,
     restore_token: Option<RestoreToken>,
     node_id: Option<u32>,
     sequence: u64,
@@ -26,6 +29,7 @@ impl PortalBackend {
             pipewire_stream: None,
             region: Rectangle::new(0, 0, 1920, 1080),
             screen_size: (1920, 1080),
+            portal_reported_size: None,
             restore_token: None,
             node_id: None,
             sequence: 0,
@@ -39,6 +43,7 @@ impl PortalBackend {
             pipewire_stream: None,
             region: Rectangle::new(0, 0, 1920, 1080),
             screen_size: (1920, 1080),
+            portal_reported_size: None,
             restore_token: Some(token),
             node_id: None,
             sequence: 0,
@@ -48,6 +53,34 @@ impl PortalBackend {
     /// Get the restore token if available.
     pub fn restore_token(&self) -> Option<&RestoreToken> {
         self.portal.as_ref()?.restore_token()
+    }
+
+    /// Scale a region from portal-reported coordinate space to actual stream
+    /// pixel space. Under Wayland fractional scaling, the portal may report a
+    /// logical size (e.g. 3840x1620) while the PipeWire stream delivers frames
+    /// at the native resolution (e.g. 5120x2160).
+    fn scale_region_to_stream(&self, region: Rectangle, stream_size: (u32, u32)) -> Rectangle {
+        let (stream_w, stream_h) = stream_size;
+        if let Some((portal_w, portal_h)) = self.portal_reported_size {
+            if stream_w > 0 && stream_h > 0
+                && (stream_w != portal_w || stream_h != portal_h)
+            {
+                let scale_x = stream_w as f64 / portal_w as f64;
+                let scale_y = stream_h as f64 / portal_h as f64;
+                debug!(
+                    "[PortalBackend] Scaling region {:?}: portal={}x{}, stream={}x{}, \
+                     scale={:.4}x{:.4}",
+                    region, portal_w, portal_h, stream_w, stream_h, scale_x, scale_y
+                );
+                return Rectangle::new(
+                    (region.x as f64 * scale_x) as i32,
+                    (region.y as f64 * scale_y) as i32,
+                    (region.width as f64 * scale_x) as u32,
+                    (region.height as f64 * scale_y) as u32,
+                );
+            }
+        }
+        region
     }
 
     /// Check if running on Wayland.
@@ -96,54 +129,90 @@ impl CaptureBackend for PortalBackend {
             stream_info.node_id, stream_info.width, stream_info.height);
         
         self.screen_size = (stream_info.width, stream_info.height);
+        self.portal_reported_size = Some((stream_info.width, stream_info.height));
         self.node_id = Some(stream_info.node_id);
-        
+
         // Get PipeWire fd from portal
         let pipewire_fd = portal.pipewire_fd()
             .ok_or_else(|| CaptureError::InitFailed("No PipeWire fd from portal".to_string()))?;
-        
+
         debug!("[PortalBackend] Got PipeWire fd: {}", pipewire_fd);
-        
+
         // Connect to PipeWire stream using portal's fd
         debug!("[PortalBackend] Connecting to PipeWire node {}...", stream_info.node_id);
         let pw_stream = PipeWireStream::connect_with_fd(stream_info.node_id, pipewire_fd).await
             .map_err(|e| CaptureError::InitFailed(format!("PipeWire connect failed: {}", e)))?;
-        
+
         debug!("[PortalBackend] PipeWire connected, waiting for frames...");
         // Give PipeWire time to start receiving frames
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-        
+
+        // Update screen_size from actual PipeWire stream dimensions, which may
+        // differ from portal-reported size under Wayland fractional scaling.
+        let (actual_w, actual_h) = pw_stream.stream_size();
+        if actual_w > 0 && actual_h > 0
+            && (actual_w != self.screen_size.0 || actual_h != self.screen_size.1)
+        {
+            info!(
+                "[PortalBackend] Fractional scaling detected: portal reported {}x{}, \
+                 stream actual {}x{}",
+                self.screen_size.0, self.screen_size.1, actual_w, actual_h
+            );
+            self.screen_size = (actual_w, actual_h);
+        }
+
         self.portal = Some(portal);
         self.pipewire_stream = Some(pw_stream);
-        
+
         info!("[PortalBackend] Initialization complete");
         Ok(())
     }
 
     async fn capture_frame(&mut self) -> Result<Frame> {
+        let stream_size = self.pipewire_stream.as_ref()
+            .map(|s| s.stream_size())
+            .unwrap_or((0, 0));
+        let region = self.scale_region_to_stream(self.region, stream_size);
+
         let pw_stream = self.pipewire_stream.as_mut()
             .ok_or_else(|| CaptureError::CaptureFailed("PipeWire not initialized".to_string()))?;
-        
-        let frame = pw_stream.capture_frame(self.region).await?;
+        let frame = pw_stream.capture_frame(region).await?;
         self.sequence += 1;
-        
+
         trace!("[PortalBackend] Captured frame #{}: {}x{}", self.sequence, frame.width, frame.height);
-        
+
         Ok(frame)
     }
 
     async fn capture_screenshot(&mut self) -> Result<Frame> {
         let pw_stream = self.pipewire_stream.as_mut()
             .ok_or_else(|| CaptureError::CaptureFailed("PipeWire not initialized".to_string()))?;
-        
+
         debug!("[PortalBackend] Capturing screenshot...");
-        // For screenshot, capture the full screen
-        let full_region = Rectangle::new(0, 0, self.screen_size.0, self.screen_size.1);
+
+        // Use actual stream dimensions for full-screen capture, since the
+        // portal-reported size may differ under fractional scaling.
+        let (stream_w, stream_h) = pw_stream.stream_size();
+        let (w, h) = if stream_w > 0 && stream_h > 0 {
+            (stream_w, stream_h)
+        } else {
+            self.screen_size
+        };
+        let full_region = Rectangle::new(0, 0, w, h);
         let frame = pw_stream.capture_frame(full_region).await?;
         self.sequence += 1;
-        
+
+        // Update screen_size if it changed (first frame may arrive late)
+        if frame.width != self.screen_size.0 || frame.height != self.screen_size.1 {
+            debug!(
+                "[PortalBackend] Updating screen_size from {}x{} to {}x{}",
+                self.screen_size.0, self.screen_size.1, frame.width, frame.height
+            );
+            self.screen_size = (frame.width, frame.height);
+        }
+
         debug!("[PortalBackend] Screenshot captured: {}x{}", frame.width, frame.height);
-        
+
         Ok(frame)
     }
 
@@ -178,5 +247,91 @@ impl CaptureBackend for PortalBackend {
             let _ = portal.close().await;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to create a PortalBackend with specific portal-reported size.
+    fn backend_with_portal_size(portal_w: u32, portal_h: u32) -> PortalBackend {
+        let mut backend = PortalBackend::new();
+        backend.portal_reported_size = Some((portal_w, portal_h));
+        backend
+    }
+
+    #[test]
+    fn scale_region_fractional_scaling_133_percent() {
+        // 133% scaling: portal reports 3840x1620, stream delivers 5120x2160
+        let backend = backend_with_portal_size(3840, 1620);
+        let region = Rectangle::new(100, 200, 800, 600);
+        let scaled = backend.scale_region_to_stream(region, (5120, 2160));
+
+        // scale = 5120/3840 = 1.3333, 2160/1620 = 1.3333
+        assert_eq!(scaled.x, 133);   // 100 * 1.3333
+        assert_eq!(scaled.y, 266);   // 200 * 1.3333
+        assert_eq!(scaled.width, 1066);  // 800 * 1.3333
+        assert_eq!(scaled.height, 800);  // 600 * 1.3333
+    }
+
+    #[test]
+    fn scale_region_fractional_scaling_150_percent() {
+        // 150% scaling: portal reports 1280x720, stream delivers 1920x1080
+        let backend = backend_with_portal_size(1280, 720);
+        let region = Rectangle::new(50, 100, 640, 360);
+        let scaled = backend.scale_region_to_stream(region, (1920, 1080));
+
+        // scale = 1920/1280 = 1.5, 1080/720 = 1.5
+        assert_eq!(scaled.x, 75);
+        assert_eq!(scaled.y, 150);
+        assert_eq!(scaled.width, 960);
+        assert_eq!(scaled.height, 540);
+    }
+
+    #[test]
+    fn scale_region_no_scaling_needed() {
+        // No fractional scaling: portal reports same as stream
+        let backend = backend_with_portal_size(1920, 1080);
+        let region = Rectangle::new(100, 200, 800, 600);
+        let scaled = backend.scale_region_to_stream(region, (1920, 1080));
+
+        // No change expected
+        assert_eq!(scaled, region);
+    }
+
+    #[test]
+    fn scale_region_no_portal_size() {
+        // No portal size stored (e.g., backend not yet initialized)
+        let backend = PortalBackend::new();
+        let region = Rectangle::new(100, 200, 800, 600);
+        let scaled = backend.scale_region_to_stream(region, (5120, 2160));
+
+        // No change expected when portal_reported_size is None
+        assert_eq!(scaled, region);
+    }
+
+    #[test]
+    fn scale_region_zero_stream_size() {
+        // Stream size not yet known (0x0)
+        let backend = backend_with_portal_size(3840, 1620);
+        let region = Rectangle::new(100, 200, 800, 600);
+        let scaled = backend.scale_region_to_stream(region, (0, 0));
+
+        // No change expected when stream size is zero
+        assert_eq!(scaled, region);
+    }
+
+    #[test]
+    fn scale_region_origin() {
+        // Region at origin should stay at origin
+        let backend = backend_with_portal_size(3840, 1620);
+        let region = Rectangle::new(0, 0, 3840, 1620);
+        let scaled = backend.scale_region_to_stream(region, (5120, 2160));
+
+        assert_eq!(scaled.x, 0);
+        assert_eq!(scaled.y, 0);
+        assert_eq!(scaled.width, 5120);
+        assert_eq!(scaled.height, 2160);
     }
 }


### PR DESCRIPTION
# Vibe code disclaimer
**I do not understand the changes made in this PR.** I cannot vouch for correctness, quality or even security.

That being said, Claude detected the same issue for #16 in the (legacy, v1) Python-based code. The fix for [that branch](https://github.com/drjayvee/region-to-share/tree/fix/wayland-fractional-scaling) does work on my machine.

The remainder of this description, together with the commit message and changes made to code and tests, were all fully written by Claude Code.

I won't be offended *at all* if you decide to close this PR because it's vibe coded.

# Claude Code

On Wayland with fractional scaling, the XDG Desktop Portal may report a logical stream size (e.g. 3840x1620) while PipeWire delivers frames at the native resolution (e.g. 5120x2160). This mismatch caused the captured region to be offset from the user's selection and the screenshot to show only part of the screen.

Fix by tracking the portal-reported size separately, updating screen_size from actual PipeWire stream dimensions, and scaling crop coordinates in capture_frame() and capture_screenshot(). Includes unit tests for the scaling logic and extract_region cropping.