### PR TITLE
fix: capture screenshot at native resolution on fractional scaling

### DIFF
--- a/crates/region-portal/src/pipewire.rs
+++ b/crates/region-portal/src/pipewire.rs
@@ -209,6 +209,74 @@ fn extract_region(frame: &PipeWireFrame, region: &Rectangle) -> Arc<Vec<u8>> {
     Arc::new(dst)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_frame(width: u32, height: u32) -> PipeWireFrame {
+        let bpp = 4;
+        let size = (width * height * bpp as u32) as usize;
+        let mut data = vec![0u8; size];
+        // Fill with a pattern: each pixel's first byte = (x + y * width) % 256
+        for y in 0..height {
+            for x in 0..width {
+                let offset = ((y * width + x) as usize) * bpp;
+                data[offset] = ((x + y * width) % 256) as u8;
+                data[offset + 1] = 0;
+                data[offset + 2] = 0;
+                data[offset + 3] = 255;
+            }
+        }
+        PipeWireFrame {
+            width,
+            height,
+            data: Arc::new(data),
+            format: PixelFormat::BGRA8888,
+            timestamp: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn extract_region_full_frame() {
+        let frame = make_frame(100, 100);
+        let region = Rectangle::new(0, 0, 100, 100);
+        let result = extract_region(&frame, &region);
+        assert_eq!(result.len(), frame.data.len());
+    }
+
+    #[test]
+    fn extract_region_subset() {
+        let frame = make_frame(100, 100);
+        let region = Rectangle::new(10, 20, 30, 40);
+        let result = extract_region(&frame, &region);
+        let bpp = 4;
+        let expected_size = 30 * 40 * bpp;
+        assert_eq!(result.len(), expected_size);
+
+        // Verify first pixel of extracted region matches source
+        let src_offset = (20 * 100 + 10) * bpp;
+        assert_eq!(result[0], frame.data[src_offset]);
+    }
+
+    #[test]
+    fn extract_region_with_scaled_coordinates() {
+        // Simulate fractional scaling: frame is 5120x2160, region is in
+        // scaled coordinates that have been properly adjusted
+        let frame = make_frame(200, 100);
+
+        // Without scaling: region at (75, 50, 50, 25) in a 150x75 logical space
+        // After scaling by 200/150 = 1.333: (100, 66, 66, 33)
+        let scaled_region = Rectangle::new(100, 66, 66, 33);
+        let result = extract_region(&frame, &scaled_region);
+        let bpp = 4;
+        assert_eq!(result.len(), 66 * 33 * bpp);
+
+        // Verify first pixel comes from the right source position
+        let src_offset = (66 * 200 + 100) * bpp;
+        assert_eq!(result[0], frame.data[src_offset]);
+    }
+}
+
 /// Run the PipeWire main loop with portal fd (must run on its own thread).
 fn run_pipewire_loop_with_fd(
     node_id: u32,

--- a/crates/region-portal/src/stream.rs
+++ b/crates/region-portal/src/stream.rs
@@ -135,15 +135,34 @@ impl CaptureBackend for PortalBackend {
     async fn capture_screenshot(&mut self) -> Result<Frame> {
         let pw_stream = self.pipewire_stream.as_mut()
             .ok_or_else(|| CaptureError::CaptureFailed("PipeWire not initialized".to_string()))?;
-        
+
         debug!("[PortalBackend] Capturing screenshot...");
-        // For screenshot, capture the full screen
-        let full_region = Rectangle::new(0, 0, self.screen_size.0, self.screen_size.1);
-        let frame = pw_stream.capture_frame(full_region).await?;
+        // First capture to discover actual PipeWire frame dimensions.
+        // Portal-reported size may differ from the native stream resolution
+        // (e.g. portal says 3840x2160 but PipeWire delivers 5120x2160).
+        // After this call, pw_stream.stream_size() returns the real dimensions.
+        let probe_region = Rectangle::new(0, 0, self.screen_size.0, self.screen_size.1);
+        let _ = pw_stream.capture_frame(probe_region).await?;
+
+        let (actual_w, actual_h) = pw_stream.stream_size();
+        let frame = if actual_w != self.screen_size.0 || actual_h != self.screen_size.1 {
+            info!(
+                "[PortalBackend] Actual stream size: {}x{} (portal reported: {}x{})",
+                actual_w, actual_h, self.screen_size.0, self.screen_size.1
+            );
+            self.screen_size = (actual_w, actual_h);
+            // Recapture at the correct native resolution
+            let full_region = Rectangle::new(0, 0, actual_w, actual_h);
+            pw_stream.capture_frame(full_region).await?
+        } else {
+            // Portal size matches stream — the probe result was already correct,
+            // but we discarded it, so capture once more.
+            pw_stream.capture_frame(probe_region).await?
+        };
         self.sequence += 1;
-        
+
         debug!("[PortalBackend] Screenshot captured: {}x{}", frame.width, frame.height);
-        
+
         Ok(frame)
     }
 
@@ -178,5 +197,33 @@ impl CaptureBackend for PortalBackend {
             let _ = portal.close().await;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_backend() {
+        let backend = PortalBackend::new();
+        assert!(backend.portal.is_none());
+        assert!(backend.pipewire_stream.is_none());
+        assert_eq!(backend.screen_size, (1920, 1080));
+        assert_eq!(backend.sequence, 0);
+    }
+
+    #[test]
+    fn test_default_backend() {
+        let backend = PortalBackend::default();
+        assert!(backend.portal.is_none());
+        assert!(backend.pipewire_stream.is_none());
+        assert_eq!(backend.screen_size, (1920, 1080));
+    }
+
+    #[test]
+    fn test_is_wayland() {
+        // Just verify the method doesn't panic
+        let _ = PortalBackend::is_wayland();
     }
 }


### PR DESCRIPTION
# Vibe code disclaimer

I do not understand the changes made in this PR. I cannot vouch for correctness, quality or even security.

The remainder of this description, together with the commit message and changes made to code and tests, were all fully written by Claude Code.

I won't be offended at all if you decide to close this PR because it's vibe coded.

# Claude says
On Wayland with fractional scaling, the portal reports a logical screen size that differs from the actual PipeWire stream resolution. The screenshot was cropped to the portal-reported size, cutting off part of the screen and causing a visual rescale effect during region selection.

Fix by probing the actual stream dimensions on first capture, then recapturing at the correct native resolution.