### PR TITLE
chore: 🔄 Bump version to 2.1.2 in Cargo.toml and snapcraft.yaml

### DIFF
--- a/crates/region-ui-egui/Cargo.toml
+++ b/crates/region-ui-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "region-ui-egui"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 
 [dependencies]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,32 +1,9 @@
 name: region-to-share
 base: core24
-version: '2.1.1'
+version: '2.1.2'
 title: Region to Share
 summary: Share selected screen regions in video calls
-description: |
-  Region to Share allows you to select a specific area of your screen
-  and display it in a window that you can share directly 
-  in your video conferencing applications (Google Meet, Teams, Discord, etc.).
-
-  Version 2.1.1 beta channel Complete Rust rewrite with improved performance.
-  
-  What's new:
-  - Native Rust implementation (no Python dependencies)
-  - Lower CPU usage
-  - Native Wayland support via XDG Desktop Portal
-  - Native X11 support
-  - Modern egui interface
-  - Smaller binary size
-
-  Features:
-  - Interactive region selection
-  - High-performance real-time display
-  - Works on X11 and Wayland (GNOME, KDE, Sway, Hyprland, etc.)
-  - Performance monitoring overlay
-  - Adjustable window opacity
-  - Remember last region for quick reuse
-
-  BETA: This is a beta version. Please report issues on GitHub.
+description: 
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
to rebuild and fix libxml2: 8456-1